### PR TITLE
removed dependency pandas

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,6 @@ pylandsat list-available-files LT05
 ``` python
 from datetime import datetime
 
-import pandas as pd
 from shapely.geometry import Point
 from pylandsat import Catalog, Product
 
@@ -162,7 +161,7 @@ begin = datetime(2000, 1, 1)
 end = datetime(2010, 1, 1)
 geom = Point(4.34, 50.85)
 
-# Results are returned as a pandas dataframe
+# Results are returned as a list
 scenes = catalog.search(
     begin=begin,
     end=end,

--- a/pylandsat/catalog.py
+++ b/pylandsat/catalog.py
@@ -25,7 +25,7 @@ def _to_list(value):
         return [value]
 
 
-class Catalog():
+class Catalog:
     """Perform queries on the Landsat catalog."""
 
     def __init__(self):
@@ -61,8 +61,8 @@ class Catalog():
 
         Returns
         -------
-        scenes : dataframe
-            Search results as a pandas dataframe.
+        scenes : List
+            Search results as a list.
         """
         # Convert strings to list if necessary
         path, row = _to_list(path), _to_list(row)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ appdirs
 requests
 fiona
 shapely
-pandas
 tqdm
 numpy
 rasterio

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='pylandsat',
-    version='0.2',
+    version='0.4',
     description='Search, download and preprocess Landsat imagery',
     long_description=LONG_DESC,
     long_description_content_type='text/markdown',
@@ -37,7 +37,6 @@ setup(
         'requests',
         'fiona',
         'shapely',
-        'pandas',
         'tqdm',
         'numpy',
         'rasterio',


### PR DESCRIPTION
Thanks for `pylandsat`, it's quite useful for [`ukis-pysat`](https://github.com/dlr-eoc/ukis-pysat). In 6d7f5d5a43d4e380495521534be75de3625eb218 you basically removed pandas as a dependency, but it gets still installed. Would you mind updating this?