### PR TITLE
Correct order of parameters when syncing database

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ To allow large and fast queries, **pylandsat** works with a local dump of the La
 pylandsat sync-database
 
 # Force update
-pylandsat -f sync-database
+pylandsat sync-database -f
 ```
 
 The database is stored in a local directory that can be displayed using the following command :


### PR DESCRIPTION
I think there is a mistake in the documentation README.md. The **correct** order is `pylandsat sync-database -f` instead of `pylandsat -f sync-database` when trying to sync with the database. I dealt with this issue using Anaconda prompt in Windows 10.
![Screenshot 2021-02-04 12 48 20](https://user-images.githubusercontent.com/39352874/106882548-8cc2fe80-66e7-11eb-8287-df8d8c8772d1.png)

